### PR TITLE
metal provider name attribute and fog key pair name resolution

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@
 default['chef-server-cluster']['topology'] = 'tier'
 default['chef-server-cluster']['role'] = 'frontend'
 default['chef-server-cluster']['bootstrap']['enable'] = false
-#default['chef-server-cluster']['metal-provisioner-key-name'] = 'hc-metal-provisioner'
+default['chef-server-cluster']['metal-provisioner-key-name'] = 'hc-metal-provisioner-chef-aws-us-west-2'
 
 # these use _ instead of - because it maps to the machine_options in
 # chef-metal-fog.

--- a/recipes/metal-provision.rb
+++ b/recipes/metal-provision.rb
@@ -27,10 +27,7 @@ include_recipe 'chef-server-cluster::metal'
 # we're ready for that.
 #ssh_keys = chef_vault_item('vault', node['chef-server-cluster']['metal-provisioner-key-name'])['data']
 
-#ssh_keys = data_bag_item('secrets', 'hc-metal-provisioner-chef-aws-us-west-2')
-
-key_name = node['chef-server-cluster']['aws']['machine_options']['bootstrap_options']['key_name']
-ssh_keys = data_bag_item('secrets', key_name)
+ssh_keys = data_bag_item('secrets', node['chef-server-cluster']['metal-provisioner-key-name'])
 
 directory '/tmp/ssh' do
   recursive true
@@ -50,7 +47,7 @@ file '/tmp/ssh/id_rsa.pub' do
   sensitive true
 end
 
-fog_key_pair key_name do
+fog_key_pair node['chef-server-cluster']['aws']['machine_options']['bootstrap_options']['key_name'] do
   private_key_path '/tmp/ssh/id_rsa'
   public_key_path '/tmp/ssh/id_rsa.pub'
 end


### PR DESCRIPTION
Added new attribute so ssh keys can be loaded from a different data bag ['chef-server-cluster']['metal-provisioner-key-name'].  I saw the chef-vault comment, but figured this was a good first step.

fog_key_pair resource sets the name based on the node['chef-server-cluster']['aws']['machine_options']['bootstrap_options']['key_name'] attribute.

These changes allowed my mvp repo to succeed. https://github.com/patrick-wright/csc-repo
