### PR TITLE
Lwrp for creating admin users and orgs

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,14 +1,18 @@
 ---
 driver:
   name: vagrant
+
+driver_config:
   customize:
-    memory: 512
+    memory: 2048
+    cpus: 2
 
 provisioner:
   name: chef_zero
 
 platforms:
   - name: ubuntu-14.04
+  - name: centos-6.5
 
 suites:
   - name: fullstack
@@ -40,3 +44,13 @@ suites:
           enable: true
         opscode_webui:
           enable: true
+
+  - name: standalone
+    run_list:
+      - recipe[test::standalone_hostsfile]
+      - recipe[chef-server-cluster::standalone]
+      - recipe[test::admin_org]
+    attributes:
+    driver_config:
+      network:
+      - ["private_network", {ip: "33.33.33.10"}]

--- a/Berksfile
+++ b/Berksfile
@@ -1,10 +1,10 @@
-source 'https://supermarket.getchef.com'
+source 'https://supermarket.chef.io'
 
 metadata
 
 group :integration do
-  cookbook 'test', :path => './test/fixtures/cookbooks/test'
+  cookbook 'test', :path => 'test/fixtures/cookbooks/test'
 end
 
 # This cookbook isn't on supermarket.
-cookbook 'chef-server-ingredient', github: 'opscode-cookbooks/chef-server-ingredient'
+cookbook 'chef-server-ingredient', github: 'stephenlauck/chef-server-ingredient', branch: 'reconfigure_parameter_for_install'

--- a/libraries/provider_chef_server_cluster_org.rb
+++ b/libraries/provider_chef_server_cluster_org.rb
@@ -1,0 +1,41 @@
+require 'chef/provider/lwrp_base'
+
+class Chef
+  class Provider
+    class ChefServerClusterOrg < Chef::Provider::LWRPBase
+
+      use_inline_resources if defined?(use_inline_resources)
+
+      def whyrun_supported?
+        true
+      end
+
+      action :create do
+        execute 'create org' do
+          command <<-EOM.gsub(/\s+/, ' ').strip!
+            chef-server-ctl org-create #{new_resource.org_name}
+            #{new_resource.org_long_name}
+            -f #{new_resource.org_private_key_path}
+          EOM
+          not_if "chef-server-ctl org-list | grep -w #{new_resource.org_name}"
+        end
+      end
+
+      action :delete do
+        # delete org
+      end
+
+      action :add_admin do
+        new_resource.admins.each do |admin|
+          execute 'add users to org' do
+            command <<-EOM.gsub(/\s+/, ' ').strip!
+              chef-server-ctl org-user-add #{new_resource.org_name} #{admin}
+              --admin
+            EOM
+            # not_if "chef-server-ctl org-list | grep -w #{new_resource.org_name}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/libraries/provider_chef_server_cluster_user.rb
+++ b/libraries/provider_chef_server_cluster_user.rb
@@ -1,0 +1,32 @@
+require 'chef/provider/lwrp_base'
+
+class Chef
+  class Provider
+    class ChefServerClusterUser < Chef::Provider::LWRPBase
+
+      use_inline_resources if defined?(use_inline_resources)
+
+      def whyrun_supported?
+        true
+      end
+
+      action :create do
+        execute 'create user' do
+          command <<-EOM.gsub(/\s+/, ' ').strip!
+            chef-server-ctl user-create #{new_resource.username}
+            #{new_resource.firstname}
+            #{new_resource.lastname}
+            #{new_resource.email}
+            #{new_resource.password}
+            -f #{new_resource.private_key_path}
+          EOM
+          not_if "chef-server-ctl user-list | grep -w #{new_resource.username}"
+        end
+      end
+
+      action :delete do
+        # delete user
+      end
+    end
+  end
+end

--- a/libraries/resource_chef_server_cluster_org.rb
+++ b/libraries/resource_chef_server_cluster_org.rb
@@ -1,0 +1,16 @@
+require 'chef/resource/lwrp_base'
+
+class Chef
+  class Resource
+    class ChefServerClusterOrg < Chef::Resource::LWRPBase
+      self.resource_name = :chef_server_org
+      actions :create, :delete, :add_admin
+      default_action :create
+
+      attribute :org_name, kind_of: String, name_attribute: true, required: true
+      attribute :org_long_name, kind_of: String, default: nil
+      attribute :org_private_key_path, kind_of: String, default: nil
+      attribute :admins, kind_of: [String, Array], default: nil
+    end
+  end
+end

--- a/libraries/resource_chef_server_cluster_user.rb
+++ b/libraries/resource_chef_server_cluster_user.rb
@@ -1,0 +1,18 @@
+require 'chef/resource/lwrp_base'
+
+class Chef
+  class Resource
+    class ChefServerClusterUser < Chef::Resource::LWRPBase
+      self.resource_name = :chef_server_user
+      actions :create, :delete
+      default_action :create
+
+      attribute :username, kind_of: String, name_attribute: true, required: true
+      attribute :firstname, kind_of: String, default: nil
+      attribute :lastname, kind_of: String, default: nil
+      attribute :email, kind_of: String, default: nil
+      attribute :password, kind_of: String, default: nil
+      attribute :private_key_path, kind_of: String, default: nil
+    end
+  end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,5 +32,6 @@ directory '/etc/opscode-reporting' do
 end
 
 chef_server_ingredient 'chef-server-core' do
-  notifies :reconfigure, 'chef_server_ingredient[chef-server-core]'
+  reconfigure true
+  action :install
 end

--- a/test/fixtures/cookbooks/test/metadata.rb
+++ b/test/fixtures/cookbooks/test/metadata.rb
@@ -1,2 +1,5 @@
 name 'test'
 version '0.0.1'
+
+depends 'chef-server-cluster'
+depends 'hostsfile'

--- a/test/fixtures/cookbooks/test/recipes/admin_org.rb
+++ b/test/fixtures/cookbooks/test/recipes/admin_org.rb
@@ -1,0 +1,22 @@
+
+chef_server_cluster_user 'flock' do
+  firstname 'Florian'
+  lastname 'Lock'
+  email 'ops@example.com'
+  password 'DontUseThis4Real'
+  private_key_path '/tmp/flock.pem'
+  action :create
+  notifies :reconfigure, 'chef_server_ingredient[chef-server-core]'
+end
+
+chef_server_cluster_org 'example' do
+  org_long_name 'Example Organization'
+  org_private_key_path '/tmp/example-validator.pem'
+  action :create
+  notifies :reconfigure, 'chef_server_ingredient[chef-server-core]'
+end
+
+chef_server_cluster_org 'example' do
+  admins %w{ flock }
+  action :add_admin
+end

--- a/test/fixtures/cookbooks/test/recipes/standalone_hostsfile.rb
+++ b/test/fixtures/cookbooks/test/recipes/standalone_hostsfile.rb
@@ -1,0 +1,4 @@
+hostsfile_entry '33.33.33.10' do
+  hostname  node['fqdn']
+  unique    true
+end

--- a/test/integration/standalone/serverspec/assert_created_spec.rb
+++ b/test/integration/standalone/serverspec/assert_created_spec.rb
@@ -1,0 +1,12 @@
+require 'serverspec'
+
+# Required by serverspec
+set :backend, :exec
+
+describe command('chef-server-ctl user-list') do
+  its(:stdout) { should match /flock/}
+end
+
+describe command('chef-server-ctl org-list') do
+  its(:stdout) { should match /example/}
+end


### PR DESCRIPTION
I wanted to be able to create a default Org and admin user when bringing up Chef server.

Added lwrp for org and admin. 
Added a suite to kitchen for testing on a standalone instance. 
Added recipe to test cookbook and added tests for lwrp.

This pull request relies on https://github.com/opscode-cookbooks/chef-server-ingredient/pull/5 in order for the chef-server-ctl to be avail to create the orgs/users.
